### PR TITLE
(test) add simple benchmarks

### DIFF
--- a/bencmarks/der-to-jose.js
+++ b/bencmarks/der-to-jose.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var derToJose = require('..').derToJose;
+
+var sigs = [
+	['MEUCIQD0nDQE4uBS6JuklnyACfPQRB/LMEh5Stq6sAfp38k6ewIgHvhX59iuruBiFpVkg3dQKJ3+Wk29lJmXfxp6ciRdj+Q=', 'ES256'],
+	['MGUCMADcY5icKo+sLF0YCh5eVzju55Elt3Dfu4geMMDnUlLNaEO8NiCFzCHeqMx7mW5GMwIxAI6sp8ihHjRJ0sn/WV6mZCxN6/5lEg1QZJ5eiUHYv2kBgmiJ/Yv1pnqqFY3gVDBp/g==', 'ES384'],
+	['MIGHAkFgiYpVsYxx6XiQp2OXscRW/PrbEcoime/FftP+B7x4QVa+M3KZzXlfP66zKqjo7O3nwK2s8GbTftW8H4HwojzimwJCAYQNsozTpCo5nwIkBgelcfIQ0y/U/60TbNH1+rlKpFDCFs6Q1ro7R1tjtXoAUb9aPIOVyXGiSQX/+fcmmWs1rkJU', 'ES512']
+];
+
+module.exports.compare = {
+	derToJose: function () {
+		for (var i = 0, n = sigs.length; i < n; ++i) {
+			derToJose.apply(null, sigs[i]);
+		}
+	}
+};
+
+module.exports.compareCount = 20;
+module.exports.countPerLap = sigs.length;
+
+require('bench').runMain();

--- a/bencmarks/jose-to-der.js
+++ b/bencmarks/jose-to-der.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var joseToDer = require('..').joseToDer;
+
+var sigs = [
+	['yA4WNemRpUreSh9qgMh_ePGqhgn328ghJ_HG7WOBKQV98eFNm3FIvweoiSzHvl49Z6YTdV4Up7NDD7UcZ-52cw', 'ES256'],
+	['TsS1fXqgq5S2lpjO-Tz5w6ZAKqNFuQ6PufvXRN2NRY2DEsQ3iUXdEcAzcMXNqVehkZ-NwUxdIvDqwKTGLYQYVhjBxkdnwm1T5VKG2v1BYFeDQ91sgBlVhHFzvFty5wCI', 'ES384'],
+	['AFKapY_5gq60n8NZ_C2iOQFov7sXgcMyDzCrnGsbvE7OlSBKbgj95aZ7GtdSdbw6joK2jjWJio8IgKNB9o11GdMTADfLUsv9oAJvmIApsmsPBAIe1vH8oeHYiDMBEz9OQcwS5eL-r1iO2v7oxzl9zZb1rA5kzBqS93ARCPKbjgcr602r', 'ES512']
+];
+
+module.exports.compare = {
+	joseToDer: function () {
+		for (var i = 0, n = sigs.length; i < n; ++i) {
+			joseToDer.apply(null, sigs[i]);
+		}
+	}
+};
+
+module.exports.compareCount = 20;
+module.exports.countPerLap = sigs.length;
+
+require('bench').runMain();

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "base64-url": "^1.2.1"
   },
   "devDependencies": {
+    "bench": "^0.3.5",
     "chai": "^3.0.0",
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.15",


### PR DESCRIPTION
Just run .js with node.

They error because I'm not comparing two things, but oh well.

Scores are in kHz

Example output:

```
Scores: (bigger is better)

joseToDer
Raw:
 > 47.29064039408867
 > 47.57185332011893
 > 47.57185332011893
 > 47.76119402985075
 > 47.666335650446875
 > 47.85643070787637
 > 47.430830039525695
 > 47.47774480712166
 > 47.61904761904762
 > 47.808764940239044
 > 46.73807205452775
 > 47.666335650446875
 > 47.57185332011893
 > 47.337278106508876
 > 47.47774480712166
 > 47.666335650446875
 > 47.337278106508876
 > 47.666335650446875
 > 46.9208211143695
 > 47.76119402985075
Average (mean) 47.50989716593907
```
