### PR TITLE
(perf) don't copy input buffers

### DIFF
--- a/benchmarks/der-to-jose.js
+++ b/benchmarks/der-to-jose.js
@@ -8,10 +8,19 @@ var sigs = [
 	['MIGHAkFgiYpVsYxx6XiQp2OXscRW/PrbEcoime/FftP+B7x4QVa+M3KZzXlfP66zKqjo7O3nwK2s8GbTftW8H4HwojzimwJCAYQNsozTpCo5nwIkBgelcfIQ0y/U/60TbNH1+rlKpFDCFs6Q1ro7R1tjtXoAUb9aPIOVyXGiSQX/+fcmmWs1rkJU', 'ES512']
 ];
 
+var sigBuffers = sigs.map(function (sig) {
+	return [new Buffer(sig[0], 'base64'), sig[1]];
+});
+
 module.exports.compare = {
-	derToJose: function () {
+	fromBase64: function () {
 		for (var i = 0, n = sigs.length; i < n; ++i) {
 			derToJose.apply(null, sigs[i]);
+		}
+	},
+	fromBuffer: function () {
+		for (var i = 0, n = sigBuffers.length; i < n; ++i) {
+			derToJose.apply(null, sigBuffers[i]);
 		}
 	}
 };

--- a/benchmarks/jose-to-der.js
+++ b/benchmarks/jose-to-der.js
@@ -8,10 +8,19 @@ var sigs = [
 	['AFKapY_5gq60n8NZ_C2iOQFov7sXgcMyDzCrnGsbvE7OlSBKbgj95aZ7GtdSdbw6joK2jjWJio8IgKNB9o11GdMTADfLUsv9oAJvmIApsmsPBAIe1vH8oeHYiDMBEz9OQcwS5eL-r1iO2v7oxzl9zZb1rA5kzBqS93ARCPKbjgcr602r', 'ES512']
 ];
 
+var sigBuffers = sigs.map(function (sig) {
+	return [new Buffer(sig[0], 'base64'), sig[1]];
+});
+
 module.exports.compare = {
-	joseToDer: function () {
+	fromBase64: function () {
 		for (var i = 0, n = sigs.length; i < n; ++i) {
 			joseToDer.apply(null, sigs[i]);
+		}
+	},
+	fromBuffer: function () {
+		for (var i = 0, n = sigBuffers.length; i < n; ++i) {
+			joseToDer.apply(null, sigBuffers[i]);
 		}
 	}
 };

--- a/src/ecdsa-sig-formatter.js
+++ b/src/ecdsa-sig-formatter.js
@@ -40,7 +40,7 @@ function bignumToBuf (bn, numBytes) {
 
 function signatureAsBuffer (signature) {
 	if (Buffer.isBuffer(signature)) {
-		return new Buffer(signature);
+		return signature;
 	} else if ('string' === typeof signature) {
 		return new Buffer(signature, 'base64');
 	}


### PR DESCRIPTION
Micro-optimiziation.

Given we don't modify input, there's no need to take a copy of an incoming buffer
