### PR TITLE
Use base64-url instead of base64url for TypeScript support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/Brightspace/node-ecdsa-sig-formatter#readme",
   "dependencies": {
+    "base64-url": "^2.2.0",
     "base64url": "^2.0.0",
     "safe-buffer": "^5.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/Brightspace/node-ecdsa-sig-formatter#readme",
   "dependencies": {
     "base64-url": "^2.2.0",
-    "base64url": "^2.0.0",
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {

--- a/src/ecdsa-sig-formatter.js
+++ b/src/ecdsa-sig-formatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var base64Url = require('base64url').fromBase64;
+var base64Url = require('base64-url').escape;
 var Buffer = require('safe-buffer').Buffer;
 
 var getParamBytesForAlg = require('./param-bytes-for-alg');


### PR DESCRIPTION
The base64url package has [issues with TypeScript](https://github.com/brianloveswords/base64url/issues/20) and there are a number of pull requests to fix it, but the package author seems to have abandoned the package.

This change switches to base64-url instead, which does not have this issue but is functionally identical.