### PR TITLE
Switch to maintained b64u package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Brightspace/node-ecdsa-sig-formatter#readme",
   "dependencies": {
-    "base64url": "^2.0.0",
+    "b64u": "^2.0.0",
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {

--- a/src/ecdsa-sig-formatter.js
+++ b/src/ecdsa-sig-formatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var base64Url = require('base64url').fromBase64;
+var base64Url = require('b64u').fromBase64;
 var Buffer = require('safe-buffer').Buffer;
 
 var getParamBytesForAlg = require('./param-bytes-for-alg');


### PR DESCRIPTION
The `base64url` package has not been updated since 2016 and currently has [a critical issue](https://github.com/brianloveswords/base64url/issues/13) that prevents TypeScript users from using it with any version of Node other than v6.0.0.  This affects both the `base64url` package and all packages that depend on it, including this one.

This PR updates replaces `base64url` with `b64u`, a maintained, API-identical equivalent package.  Since the API is identical, this should require no additional changes.