### PR TITLE
drop support for old nodejs (req v14)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": "brightspace/node-config",
   "env": {
-    "es6": false
+    "es6": true
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.12'
-  - 4
-  - 6
-  - 8
-  - 10
+  - 14
 after_success: npm run report-cov
 deploy:
   provider: npm
@@ -16,4 +12,4 @@ deploy:
   on:
     tags: true
     repo: Brightspace/node-ecdsa-sig-formatter
-    node: 10
+    node: 14

--- a/benchmarks/der-to-jose.js
+++ b/benchmarks/der-to-jose.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Buffer = require('safe-buffer').Buffer;
+var Buffer = require('buffer').Buffer;
 
 var derToJose = require('..').derToJose;
 

--- a/benchmarks/jose-to-der.js
+++ b/benchmarks/jose-to-der.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Buffer = require('safe-buffer').Buffer;
+var Buffer = require('buffer').Buffer;
 
 var joseToDer = require('..').joseToDer;
 

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   ],
   "author": "D2L Corporation",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=14.18.0"
+  },
   "bugs": {
     "url": "https://github.com/Brightspace/node-ecdsa-sig-formatter/issues"
   },
   "homepage": "https://github.com/Brightspace/node-ecdsa-sig-formatter#readme",
-  "dependencies": {
-    "safe-buffer": "^5.0.1"
-  },
   "devDependencies": {
     "bench": "^0.3.6",
     "chai": "^4.1.2",

--- a/spec/der-to-jose.js
+++ b/spec/der-to-jose.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Buffer = require('safe-buffer').Buffer,
+var Buffer = require('buffer').Buffer,
 	expect = require('chai').expect,
 	mocha = require('mocha');
 

--- a/src/ecdsa-sig-formatter.js
+++ b/src/ecdsa-sig-formatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Buffer = require('safe-buffer').Buffer;
+var Buffer = require('buffer').Buffer;
 
 var getParamBytesForAlg = require('./param-bytes-for-alg');
 
@@ -12,18 +12,12 @@ var MAX_OCTET = 0x80,
 	ENCODED_TAG_SEQ = (TAG_SEQ | PRIMITIVE_BIT) | (CLASS_UNIVERSAL << 6),
 	ENCODED_TAG_INT = TAG_INT | (CLASS_UNIVERSAL << 6);
 
-function base64Url(base64) {
-	return base64
-		.replace(/=/g, '')
-		.replace(/\+/g, '-')
-		.replace(/\//g, '_');
-}
 
 function signatureAsBuffer(signature) {
 	if (Buffer.isBuffer(signature)) {
 		return signature;
 	} else if ('string' === typeof signature) {
-		return Buffer.from(signature, 'base64');
+		return Buffer.from(signature, 'base64url');
 	}
 
 	throw new TypeError('ECDSA signature must be a Base64 string or a Buffer');
@@ -108,8 +102,7 @@ function derToJose(signature, alg) {
 	}
 	signature.copy(dst, offset, sOffset + Math.max(-sPadding, 0), sOffset + sLength);
 
-	dst = dst.toString('base64');
-	dst = base64Url(dst);
+	dst = dst.toString('base64url);
 
 	return dst;
 }


### PR DESCRIPTION
- remove dep on safe-buffer and use built in
- use base64url instead of base64 to remove util fn to convert to websafe